### PR TITLE
Added shard.yml & assumed a version number

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,0 +1,2 @@
+name: mime
+version: 0.1.0


### PR DESCRIPTION
Added a shard.yml file so that when pulling deps with [shards](https://github.com/ysbaddaden/shards) it gets the correct folder name (`mime` instead of `crystal-mime`)
