### PR TITLE
Bugfix

### DIFF
--- a/src/mime.cr
+++ b/src/mime.cr
@@ -1,6 +1,7 @@
 require "json"
 
 module Mime
+  @@map : Hash(Symbol, Hash(String, String)) | Nil
 
   def self.from_ext(ext)
     ext = ext.to_s

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -27,7 +27,7 @@ module Mime
         end
       end
 
-      { :types => types, :extensions => extensions }
+      {:types => types, :extensions => extensions}
     end
   end
 end


### PR DESCRIPTION
Getting this error while using the amethyst shard, This PR fixes the bug.

in lib/mime/src/mime.cr:7: instantiating 'map()'
    return nil unless map[:types].has_key? ext
                      ^~~
in lib/mime/src/mime.cr:17: Can't infer the type of class variable '@@map' of Mime