### PR TITLE
mime: Use []? accessors for map

### DIFF
--- a/src/mime.cr
+++ b/src/mime.cr
@@ -3,13 +3,11 @@ require "json"
 module Mime
   def self.from_ext(ext)
     ext = ext.to_s
-    return nil unless map[:types].has_key? ext
-    map[:types][ext]
+    map[:types][ext]?
   end
 
   def self.to_ext(mime)
-    return nil unless map[:extensions].has_key? mime
-    map[:extensions][mime]
+    map[:extensions][mime]?
   end
 
   private def self.map
@@ -25,7 +23,7 @@ module Mime
         end
       end
 
-      { :types => types, :extensions => extensions }
+      {:types => types, :extensions => extensions}
     end.as(Hash(Symbol, Hash(String, String)))
   end
 end


### PR DESCRIPTION
This doesn't change any behavior, just reduces the number of method calls in `from_ext` and `to_ext` by 1.

The Crystal autoformatter also changed a line, but I can undo that if you'd like.

Thanks for making `crystal-mime`!