### PR TITLE
mime: Embed JSON, use []? accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /.deps/
 /libs/
+/lib/
 /.crystal/
-
+/.shards/
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them

--- a/shard.lock
+++ b/shard.lock
@@ -1,0 +1,6 @@
+version: 1.0
+shards:
+  baked_file_system:
+    github: schovi/baked_file_system
+    commit: 668ca5f501e401c247a7c0d07fa574d65ac375e1
+

--- a/shard.yml
+++ b/shard.yml
@@ -1,2 +1,6 @@
 name: mime
 version: 0.1.1
+dependencies:
+  baked_file_system:
+    github: schovi/baked_file_system
+    branch: master

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -1,31 +1,34 @@
+require "baked_file_system"
 require "json"
 
 module Mime
+  class MimeTypesStore
+    extend BakedFileSystem
+    bake_file "types.json", File.read("src/types.json")
+  end
+
   def self.from_ext(ext)
     ext = ext.to_s
-    return nil unless map[:types].has_key? ext
-    map[:types][ext]
+    map[:types][ext.to_s]?
   end
 
   def self.to_ext(mime)
-    return nil unless map[:extensions].has_key? mime
-    map[:extensions][mime]
+    map[:extensions][mime]?
   end
 
   private def self.map
     @@map ||= begin
       types = {} of String => String
       extensions = {} of String => String
-      type_defs = File.read(File.join(__DIR__, "types.json"))
 
-      JSON.parse(type_defs).each do |type, exts|
+      JSON.parse(MimeTypesStore.get("types.json")).each do |type, exts|
         exts.each do |ext|
           types[ext.as_s] = type.as_s
           extensions[type.as_s] = ext.as_s unless extensions.has_key? type.as_s
         end
       end
 
-      { :types => types, :extensions => extensions }
+      {:types => types, :extensions => extensions}
     end.as(Hash(Symbol, Hash(String, String)))
   end
 end


### PR DESCRIPTION
This is a combination of #8 and some macro trickery to
embed `types.json` in the program itself, allowing binaries
that depend on crystal-mime to be run freestanding.