### PR TITLE
mime: 0.26.1 compatibility

### DIFF
--- a/src/mime.cr
+++ b/src/mime.cr
@@ -4,7 +4,7 @@ require "json"
 module Mime
   class MimeTypesStore
     extend BakedFileSystem
-    bake_file "types.json", File.read("src/types.json")
+    bake_file "types.json", File.read("#{__DIR__}/types.json")
   end
 
   def self.from_ext(ext)

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -21,10 +21,10 @@ module Mime
       types = {} of String => String
       extensions = {} of String => String
 
-      JSON.parse(MimeTypesStore.get("types.json")).each do |type, exts|
+      Hash(String, Array(String)).from_json(MimeTypesStore.get("types.json")).each do |type, exts|
         exts.each do |ext|
-          types[ext.as_s] = type.as_s
-          extensions[type.as_s] = ext.as_s unless extensions.has_key? type.as_s
+          types[ext] = type
+          extensions[type] = ext unless extensions.has_key? type
         end
       end
 


### PR DESCRIPTION
JSON::Any no longer provides `#each`, so use `from_json` instead
with the expected layout. Additionally, remove unneeded `as_s` calls.